### PR TITLE
Play 1.8.0

### DIFF
--- a/app/controllers/BlobController.java
+++ b/app/controllers/BlobController.java
@@ -3,7 +3,7 @@ package controllers;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mongodb.morphia.Datastore;
-import org.osgl._;
+import org.osgl.Osgl;
 import org.osgl.storage.ISObject;
 import org.osgl.storage.KeyGenerator;
 import org.osgl.util.S;
@@ -87,7 +87,7 @@ public class BlobController extends Controller {
                     }
                     Logger.info("migrating %s of %s: %s...", i++, len, s);
                     final String key = s;
-                    ss.migrate(key, new _.F1<Throwable, Void>() {
+                    ss.migrate(key, new Osgl.F1<Throwable, Void>() {
                         @Override
                         public Void apply(Throwable o) {
                             errs.incrementAndGet();

--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -1,4 +1,5 @@
 # History
+# 1.8.0   - Support for Play 1.8.0
 # 1.7     - Support for Mongo 7.0
 #         - dependencies updates
 #         - mongo-java-driver 4.11.1
@@ -53,9 +54,9 @@
 #        - trim value when processing where statement in Factory.fetch
 # 1.2.5 - mavenize project
 # 1.2.4d - Add BlobGsonAdapter and ModelFactoryGsonAdapter utilities
-self: play -> morphia 1.7.1
+self: play -> morphia 1.8.0
 require:
-    - play 1.4.4
+    - play 1.8.0
     - org.mongodb -> mongo-java-driver 3.12.14
     - org.mongodb.morphia -> morphia 1.3.2
     - org.osgl -> osgl-tool 0.3-SNAPSHOT

--- a/src/play/modules/morphia/AggregationResult.java
+++ b/src/play/modules/morphia/AggregationResult.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.mongodb.BasicDBObject;
 

--- a/src/play/modules/morphia/Blob.java
+++ b/src/play/modules/morphia/Blob.java
@@ -1,7 +1,7 @@
 package play.modules.morphia;
 
 import org.bson.types.ObjectId;
-import org.osgl._;
+import org.osgl.Osgl;
 import org.osgl.exception.UnexpectedIOException;
 import org.osgl.storage.ISObject;
 import org.osgl.storage.IStorageService;
@@ -110,7 +110,7 @@ public class Blob implements BinaryField, Serializable {
         }
 
         @Override
-        public void consumeOnce(_.Function<InputStream, ?> consumer) throws UnexpectedIOException {
+        public void consumeOnce(Osgl.Function<InputStream, ?> consumer) throws UnexpectedIOException {
             sobj.consumeOnce(consumer);
         }
     }

--- a/src/play/modules/morphia/BlobStorageService.java
+++ b/src/play/modules/morphia/BlobStorageService.java
@@ -1,6 +1,6 @@
 package play.modules.morphia;
 
-import org.osgl._;
+import org.osgl.Osgl;
 import org.osgl.exception.UnexpectedIOException;
 import org.osgl.storage.ISObject;
 import org.osgl.storage.IStorageService;
@@ -41,15 +41,15 @@ public class BlobStorageService extends StorageServiceBase implements IStorageSe
 
     private static class SJob<T> extends play.jobs.Job<T> {
 
-        _.Func0<T> func;
-        _.Func0<?> success;
-        _.Function<Throwable, Void> fail;
+        Osgl.Func0<T> func;
+        Osgl.Func0<?> success;
+        Osgl.Function<Throwable, Void> fail;
 
-        SJob(_.Func0<T> func) {
-            this(func, _.F0, _.F1);
+        SJob(Osgl.Func0<T> func) {
+            this(func, Osgl.F0, Osgl.F1);
         }
 
-        SJob(_.Func0<T> func, _.Func0<?> success, _.Function<Throwable, Void> fail) {
+        SJob(Osgl.Func0<T> func, Osgl.Func0<?> success, Osgl.Function<Throwable, Void> fail) {
             this.func = func;
             this.success = success;
             this.fail = fail;
@@ -96,7 +96,7 @@ public class BlobStorageService extends StorageServiceBase implements IStorageSe
         StringBuilder sb = new StringBuilder();
         String skgen = keygen.toString();
         sb.append(S.first(skgen, 1)).append(S.last(skgen, 1));
-        int hash = _.hc(storage, keygen);
+        int hash = Osgl.hc(storage, keygen);
         sb.append(Math.abs(hash)).append(S.first(storage, 1)).append(S.last(storage, 1));
         return sb.toString();
     }
@@ -112,13 +112,13 @@ public class BlobStorageService extends StorageServiceBase implements IStorageSe
         if (null == bss) {
             Class<? extends IStorageService> c = MorphiaPlugin.getStorageClass(storage);
             E.invalidArgIf(null == c, "cannot find storage implementation for %s", storage);
-            IStorageService ss = _.newInstance(c, keygen);
+            IStorageService ss = Osgl.newInstance(c, keygen);
             Map<String, String> ssConf = MorphiaPlugin.getStorageConfig(storage);
             ss.configure(ssConf);
             boolean migrateData = MorphiaPlugin.migrateData;
             bss = new BlobStorageService(migrateData, keygen, ss, ssKey);
             registry.put(bss.ssKey, bss);
-            bss.putAsync = Boolean.parseBoolean(_.ensureGet(ssConf.get("storage." + storage + ".put.async"), "false"));
+            bss.putAsync = Boolean.parseBoolean(Osgl.ensureGet(ssConf.get("storage." + storage + ".put.async"), "false"));
         }
         return bss;
     }
@@ -132,11 +132,11 @@ public class BlobStorageService extends StorageServiceBase implements IStorageSe
     }
 
     static void putLater(String key, ISObject sobj, IStorageService ss) {
-        putLater(key, sobj, ss, _.F0, _.F1);
+        putLater(key, sobj, ss, Osgl.F0, Osgl.F1);
     }
 
-    static void putLater(String key, ISObject sobj, IStorageService ss, _.Func0<Void> success,
-                         _.Func1<Throwable, Void> fail
+    static void putLater(String key, ISObject sobj, IStorageService ss, Osgl.Func0<Void> success,
+                         Osgl.Func1<Throwable, Void> fail
     ) {
         new SJob<Void>(IStorageService.f.put(key, sobj, ss), success, fail).now();
     }
@@ -159,13 +159,13 @@ public class BlobStorageService extends StorageServiceBase implements IStorageSe
             // try gfs first
             sobj = gs.get(key);
             if (null != sobj) {
-                putLater(key, sobj, ss, new _.F0<Void>() {
+                putLater(key, sobj, ss, new Osgl.F0<Void>() {
                     @Override
                     public Void apply() {
                         removeLater(key, gs, 60);
                         return null;
                     }
-                }, _.F1);
+                }, Osgl.F1);
             }
         }
         if (null == sobj) {
@@ -191,13 +191,13 @@ public class BlobStorageService extends StorageServiceBase implements IStorageSe
             // try gfs first
             sobj = gs.get(key);
             if (null != sobj) {
-                putLater(key, sobj, ss, new _.F0<Void>() {
+                putLater(key, sobj, ss, new Osgl.F0<Void>() {
                     @Override
                     public Void apply() {
                         removeLater(key, gs, 60);
                         return null;
                     }
-                }, _.F1);
+                }, Osgl.F1);
             }
         }
         if (null == sobj) {
@@ -213,7 +213,7 @@ public class BlobStorageService extends StorageServiceBase implements IStorageSe
     @Override
     public void put(final String key, final ISObject sobj) throws UnexpectedIOException {
         if (putAsync) {
-            putLater(key, sobj, ss, _.F0, new _.F1<Throwable, Void>() {
+            putLater(key, sobj, ss, Osgl.F0, new Osgl.F1<Throwable, Void>() {
                 @Override
                 public Void apply(Throwable e) {
                     Logger.warn(e, "error put storage object with key[%s]. persist into GridFS", key);
@@ -300,7 +300,7 @@ public class BlobStorageService extends StorageServiceBase implements IStorageSe
         }
     }
 
-    public void migrate(String key, _.Func1<Throwable, Void> fail) {
+    public void migrate(String key, Osgl.Func1<Throwable, Void> fail) {
         if (!migrateData) {
             return;
         }

--- a/src/play/modules/morphia/Model.java
+++ b/src/play/modules/morphia/Model.java
@@ -22,7 +22,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bson.types.CodeWScope;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.DatastoreImpl;

--- a/src/play/modules/morphia/MorphiaEnhancer.java
+++ b/src/play/modules/morphia/MorphiaEnhancer.java
@@ -10,7 +10,7 @@ import javassist.bytecode.annotation.EnumMemberValue;
 import javassist.bytecode.annotation.MemberValue;
 import org.mongodb.morphia.annotations.*;
 import org.mongodb.morphia.utils.IndexDirection;
-import org.osgl._;
+import org.osgl.Osgl;
 import org.osgl.storage.KeyGenerator;
 import org.osgl.util.C;
 import org.osgl.util.E;
@@ -393,7 +393,7 @@ public class MorphiaEnhancer extends Enhancer {
         ctClass.addMethod(deleteAll);
 
         // add @Transient to all blobs automatically
-        Map<String, _.T2<KeyGenerator, String>> blobs = processFields(ctClass);
+        Map<String, Osgl.T2<KeyGenerator, String>> blobs = processFields(ctClass);
         boolean hasBlobField = blobs.size() > 0;
 
         // enhance blob methods: save, delete, batchDelete, load and setters
@@ -407,11 +407,11 @@ public class MorphiaEnhancer extends Enhancer {
         ctClass.defrost();
     }
 
-    private void enhanceBlobMethods(CtClass ctClass, Map<String, _.T2<KeyGenerator, String>> blobs) throws CannotCompileException, NotFoundException {
+    private void enhanceBlobMethods(CtClass ctClass, Map<String, Osgl.T2<KeyGenerator, String>> blobs) throws CannotCompileException, NotFoundException {
         // -- get blob storage service
         StringBuilder sb = S.builder("protected play.modules.morphia.BlobStorageService bss(String field) {");
         for (String blob : blobs.keySet()) {
-            _.T2<KeyGenerator, String> anno = blobs.get(blob);
+        	Osgl.T2<KeyGenerator, String> anno = blobs.get(blob);
             sb.append(S.fmt("\nif (\"%s\".equals(field)) {\n\treturn play.modules.morphia.MorphiaPlugin.bss(%s, \"%s\");\n}", blob, KeyGenerator.class.getName() + "." + anno._1.name(), anno._2));
         }
         sb.append("\nthrow new java.lang.IllegalArgumentException(\"unknown blob field: \" + field);\n}");
@@ -432,7 +432,7 @@ public class MorphiaEnhancer extends Enhancer {
         sb = new StringBuilder("protected boolean loadBlobs() {");
         sb.append("\n\tboolean needsave = false;");
         for (String blob : blobs.keySet()) {
-            sb.append(String.format("\n\t{\n\t\t%1$s = %2$s.load((String)%3$s.ensureGet(__getBlobKey(\"%1$s\"), getBlobFileName(\"%1$s\")), bss(\"%1$s\"));\n\t\tif (null == __getBlobKey(\"%1$s\") && null != %1$s) {__setBlobKey(\"%1$s\", %1$s.getKey());save();needsave = true;}\n\t}", blob, Blob.class.getName(), _.class.getName()));
+            sb.append(String.format("\n\t{\n\t\t%1$s = %2$s.load((String)%3$s.ensureGet(__getBlobKey(\"%1$s\"), getBlobFileName(\"%1$s\")), bss(\"%1$s\"));\n\t\tif (null == __getBlobKey(\"%1$s\") && null != %1$s) {__setBlobKey(\"%1$s\", %1$s.getKey());save();needsave = true;}\n\t}", blob, Blob.class.getName(), Osgl.class.getName()));
         }
         sb.append("\n\tblobFieldsTracker.clear();\nreturn needsave;}");
         method = CtMethod.make(sb.toString(), ctClass);
@@ -452,11 +452,11 @@ public class MorphiaEnhancer extends Enhancer {
      * 3. Convert @play.data.validation.Unique to @play.modules.morphia.validation.Unique
      * 3. Return a list of names of Blob fields
      */
-    private Map<String, _.T2<KeyGenerator, String>> processFields(CtClass ctClass) throws NotFoundException, ClassNotFoundException {
+    private Map<String, Osgl.T2<KeyGenerator, String>> processFields(CtClass ctClass) throws NotFoundException, ClassNotFoundException {
         List<CtField> fields  = new ArrayList<CtField>();
         fields.addAll(Arrays.asList(ctClass.getDeclaredFields()));
         fields.addAll(Arrays.asList(ctClass.getFields()));
-        Map<String, _.T2<KeyGenerator, String>> blobs = C.newMap();
+        Map<String, Osgl.T2<KeyGenerator, String>> blobs = C.newMap();
         List<MemberValue> converterList = new ArrayList<MemberValue>();
         for (CtField cf: fields) {
             CtClass ctReturnType = cf.getType();
@@ -479,7 +479,7 @@ public class MorphiaEnhancer extends Enhancer {
                         ss = storage;
                     }
                 }
-                blobs.put(cf.getName(), _.T2(kg, ss));
+                blobs.put(cf.getName(), Osgl.T2(kg, ss));
                 continue;
             }
 

--- a/src/play/modules/morphia/MorphiaPlugin.java
+++ b/src/play/modules/morphia/MorphiaPlugin.java
@@ -13,7 +13,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.mongodb.morphia.AbstractEntityInterceptor;
 import org.mongodb.morphia.Datastore;
@@ -25,7 +25,7 @@ import org.mongodb.morphia.mapping.Mapper;
 import org.mongodb.morphia.mapping.validation.ConstraintViolationException;
 import org.mongodb.morphia.query.Criteria;
 import org.mongodb.morphia.query.Query;
-import org.osgl._;
+import org.osgl.Osgl;
 import org.osgl.storage.IStorageService;
 import org.osgl.storage.KeyGenerator;
 import org.osgl.util.C;
@@ -461,7 +461,7 @@ public final class MorphiaPlugin extends PlayPlugin {
                 if (null == ssCls) {
                     E.invalidConfiguration("cannot find serviceImpl for morphia storage: %s", s);
                 }
-                Class<? extends IStorageService> cls = _.classForName(ssCls);
+                Class<? extends IStorageService> cls = Osgl.classForName(ssCls);
                 ssMap.put(s, cls);
                 ssConfs.put(s, ssConf);
             }

--- a/src/play/modules/morphia/utils/MimeTypes.java
+++ b/src/play/modules/morphia/utils/MimeTypes.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * To change this template use File | Settings | File Templates.
  */
 public enum MimeTypes {
-    _;
+    _this_;
 
     private Map<String, String> m = new HashMap<String, String>();
 
@@ -67,7 +67,7 @@ public enum MimeTypes {
         String type = URLConnection.guessContentTypeFromName(fileName);
         if (null == type) {
             String suffix = "." + S.afterLast(fileName, ".");
-            type = _.get(suffix);
+            type = _this_.get(suffix);
         }
         return type;
     }

--- a/src/play/test/MorphiaFixtures.java
+++ b/src/play/test/MorphiaFixtures.java
@@ -77,7 +77,7 @@ public class MorphiaFixtures extends Fixtures {
 
             String renderedYaml = TemplateLoader.load(yamlFile).render();
 
-            Yaml yaml = new Yaml(new CustomClassLoaderConstructor(Play.classloader));
+            Yaml yaml = new Yaml(new CustomClassLoaderConstructor(Play.classloader, null));
             Object o = yaml.load(renderedYaml);
             if (o instanceof LinkedHashMap<?, ?>) {
                 @SuppressWarnings("unchecked") LinkedHashMap<Object, Map<?, ?>> objects = (LinkedHashMap<Object, Map<?, ?>>) o;


### PR DESCRIPTION
## Summary by Sourcery

Add support for Play Framework 1.8.0 by updating dependency versions, refactoring underscore utility references to explicit Osgl calls, and adjusting related code structures.

Enhancements:
- Replace all usages of underscore (`_.*`) utilities with corresponding `Osgl.*` methods and types.
- Rename the `MimeTypes` enum member from `_` to `_this_` to avoid naming conflicts.
- Update the YAML loader instantiation in MorphiaFixtures to match the new constructor signature.

Build:
- Bump Play requirement and project version to 1.8.0 in dependencies.yml.